### PR TITLE
Add a link to the BlobTools2 Tutorial. [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ To use a chromium-based browser (e.g. Google Chrome) in place of firefox, add `-
 blobtools view --view snail --host https://blobtoolkit.genomehubs.org --driver chromium mSciVul1_1
 ```
 
+See the [tutorial](https://blobtoolkit.genomehubs.org/blobtools2/blobtools2-tutorials/) for details.
+
 ## Docker images
 
 A set of Docker images are available from dockerhub:


### PR DESCRIPTION
This PR is a proposal related to the ticket https://github.com/blobtoolkit/blobtoolkit/issues/110 .

The updated README is [here](https://github.com/junaruga/blobtoolkit/blob/wip/doc-link/README.md).

It's useful to share how to use the `blobtools` command.
