### PR TITLE
Fix parsing of start and end positions in blast hits

### DIFF
--- a/src/blobtools/lib/hits.py
+++ b/src/blobtools/lib/hits.py
@@ -55,8 +55,8 @@ def parse_blast(blast_file, cols, results=None, index=0, evalue=1, bitscore=1):
             hit = {
                 "subject": row[cols["sseqid"]],
                 "score": score,
-                "start": int(start),
-                "end": int(end),
+                "start": int(re.sub(r'\d', '', end)),
+                "end": int(re.sub(r'\d', '', end)),
                 "file": index,
                 "title": parts[1],
             }


### PR DESCRIPTION
Lines 58 and 59 can be problematic as they convert from a substring to integer directly without removal of non-digit characters, first. This can cause problems as the format of the blast hits can vary. An example is below:

>OsmiaCornuta0005:4339602-4341170|-=70865at2157=single

If non-digit characters are not removed, the current code will pull out 4341170| instead of 4341170, throwing an integer conversion error.
